### PR TITLE
no mp when parallel is false, also ruff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@
 # Extra cache/environment folder
 .pytest_cache/
 .venv/
-dist/
+dist/# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/multiple_minimum_monte_carlo/conformer_ensemble.py
+++ b/multiple_minimum_monte_carlo/conformer_ensemble.py
@@ -181,9 +181,21 @@ class ConformerEnsemble:
                     )
             if len(calculation_input) == 0:
                 continue
-            positions_and_energies = multiproc.parallel_run_proc(
-                run_class_func, calculation_input, self.num_cpus
-            )
+
+            if self.parallel:
+                positions_and_energies = multiproc.parallel_run_proc(
+                    run_class_func, calculation_input, self.num_cpus
+                )
+            else:
+                # Run serially without multiprocessing
+                positions_and_energies = []
+                for calc_dict in calculation_input:
+                    result = run_class_func(
+                        calc_dict["cls"],
+                        calc_dict["func_name"],
+                        calc_dict["args"],
+                    )
+                    positions_and_energies.append(result)
 
             # Filter out high energy and duplicate conformers
             for positions, energy in positions_and_energies:

--- a/multiple_minimum_monte_carlo/multiproc.py
+++ b/multiple_minimum_monte_carlo/multiproc.py
@@ -48,6 +48,7 @@ def batch_dicts(dicts: List[Dict], num_workers: int) -> List[List[Dict]]:
 
     return batched_dicts
 
+
 def limit_cpu_threads(n_threads: int = 1):
     """
     Rough equivalent of torch.set_num_threads(n_threads)
@@ -57,14 +58,14 @@ def limit_cpu_threads(n_threads: int = 1):
     Call this before starting multiprocessing or heavy numeric code.
     """
     n_str = str(n_threads)
-    
+
     # Common math library environment variables
-    os.environ["OMP_NUM_THREADS"] = n_str       # OpenMP
+    os.environ["OMP_NUM_THREADS"] = n_str  # OpenMP
     os.environ["OPENBLAS_NUM_THREADS"] = n_str  # OpenBLAS
-    os.environ["MKL_NUM_THREADS"] = n_str       # Intel MKL
-    os.environ["VECLIB_MAXIMUM_THREADS"] = n_str # macOS Accelerate/vecLib
-    os.environ["NUMEXPR_NUM_THREADS"] = n_str   # NumExpr
-    os.environ["BLIS_NUM_THREADS"] = n_str      # BLIS (used by NumPy sometimes)
+    os.environ["MKL_NUM_THREADS"] = n_str  # Intel MKL
+    os.environ["VECLIB_MAXIMUM_THREADS"] = n_str  # macOS Accelerate/vecLib
+    os.environ["NUMEXPR_NUM_THREADS"] = n_str  # NumExpr
+    os.environ["BLIS_NUM_THREADS"] = n_str  # BLIS (used by NumPy sometimes)
 
     # Try to call OpenMP runtime directly if loaded
     try:
@@ -78,6 +79,7 @@ def limit_cpu_threads(n_threads: int = 1):
             pass  # not available — fine, env vars will handle it
 
     return n_threads
+
 
 def run_func(func: Callable, input_list: List[Dict], queue: mp.Queue) -> None:
     """

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -3,6 +3,7 @@ import numpy as np
 
 EV_TO_KCAL = 23.0605
 
+
 class DummyCalc:
     def __init__(self, energy=1.23):
         self._energy = energy
@@ -25,6 +26,7 @@ class DummyAtoms:
         # return a dummy positions array compatible with ASE
         return np.zeros((1, 3))
 
+
 def test_energy_returns_calculator_energy():
     atoms = DummyAtoms()
     calc = DummyCalc(4.56)
@@ -36,6 +38,7 @@ def test_energy_returns_calculator_energy():
 def test_run_applies_constraints_and_returns_tuple():
     atoms = DummyAtoms()
     calc = DummyCalc(7.89)
+
     # Provide a dummy optimizer that accepts atoms and has run()
     class DummyOpt:
         def __init__(self, atoms):

--- a/tests/test_cheminformatics.py
+++ b/tests/test_cheminformatics.py
@@ -56,11 +56,16 @@ def test_identity_checks(tmp_path):
     Chem.AllChem.EmbedMolecule(mol)
     atoms = cheminformatics.mol_to_ase_atoms(mol)
 
-    original_bonds, metal_atoms, halides = cheminformatics.initialize_mc_identity_check(atoms, mol)
+    original_bonds, metal_atoms, halides = cheminformatics.initialize_mc_identity_check(
+        atoms, mol
+    )
     # returned types
     assert isinstance(original_bonds, list)
     assert isinstance(metal_atoms, list)
     assert isinstance(halides, list)
 
     # check_identity_mc on same atoms should be True
-    assert cheminformatics.check_identity_mc(original_bonds, metal_atoms, halides, atoms) is True
+    assert (
+        cheminformatics.check_identity_mc(original_bonds, metal_atoms, halides, atoms)
+        is True
+    )

--- a/tests/test_conformer.py
+++ b/tests/test_conformer.py
@@ -13,18 +13,22 @@ def test_conformer_creates_mol_for_unmapped(monkeypatch):
     real_mf = Chem.MolFromSmiles
 
     def fake_mol_from_smiles(smi):
-        called['smi'] = smi
+        called["smi"] = smi
         return real_mf("CC")
 
     monkeypatch.setattr(Chem, "MolFromSmiles", fake_mol_from_smiles)
+
     # avoid heavy conformer generation in initializer by providing a minimal atoms object
     def fake_generate(self):
         class MinimalAtoms:
             def __init__(self):
                 self.info = {}
+
             def get_positions(self):
                 return []
+
         self.atoms = MinimalAtoms()
+
     monkeypatch.setattr(Conformer, "generate_conformer", fake_generate)
     c = Conformer("CC", mapped=False)
     assert c.smiles == "CC"
@@ -32,22 +36,27 @@ def test_conformer_creates_mol_for_unmapped(monkeypatch):
 
 def test_conformer_uses_make_mol_when_mapped(monkeypatch):
     from multiple_minimum_monte_carlo import cheminformatics
+
     called = {}
 
     def fake_make_mol(smi):
-        called['smi'] = smi
+        called["smi"] = smi
         return Chem.MolFromSmiles("CC")
 
     monkeypatch.setattr(cheminformatics, "make_mol", fake_make_mol)
+
     # avoid heavy conformer generation by providing minimal atoms
     def fake_generate(self):
         class MinimalAtoms:
             def __init__(self):
                 self.info = {}
+
             def get_positions(self):
                 return []
+
         self.atoms = MinimalAtoms()
+
     monkeypatch.setattr(Conformer, "generate_conformer", fake_generate)
     c = Conformer("[CH3:1][CH3:2]", mapped=True)
     assert hasattr(c, "mol")
-    assert called['smi'].startswith("[CH3")
+    assert called["smi"].startswith("[CH3")

--- a/tests/test_conformer_ensemble.py
+++ b/tests/test_conformer_ensemble.py
@@ -1,8 +1,12 @@
 import pytest
+
 pytest.importorskip("rdkit")
 from rdkit import Chem
 
-from multiple_minimum_monte_carlo.conformer_ensemble import ConformerEnsemble, run_class_func
+from multiple_minimum_monte_carlo.conformer_ensemble import (
+    ConformerEnsemble,
+    run_class_func,
+)
 from multiple_minimum_monte_carlo.conformer import Conformer
 
 
@@ -21,9 +25,12 @@ def make_dummy_conformer(monkeypatch):
         class MinimalAtoms:
             def __init__(self):
                 self.info = {}
+
             def get_positions(self):
                 return []
+
         self.atoms = MinimalAtoms()
+
     try:
         # if a pytest monkeypatch fixture is provided
         monkeypatch.setattr(Conformer, "generate_conformer", fake_generate)
@@ -42,7 +49,9 @@ def test_sample_conformer_minimum():
     c = make_dummy_conformer(None)
     ensemble = ConformerEnsemble(c, calc=None, num_iterations=1, parallel=False)
     # when used is [0,0,0], argmin is 0
-    assert ensemble.sample_conformer([1, 2, 3]) == 0 or isinstance(ensemble.sample_conformer([1,2,3]), int)
+    assert ensemble.sample_conformer([1, 2, 3]) == 0 or isinstance(
+        ensemble.sample_conformer([1, 2, 3]), int
+    )
 
 
 def test_constraint_test_detects_close_atoms(monkeypatch):

--- a/tests/test_multiproc.py
+++ b/tests/test_multiproc.py
@@ -2,7 +2,7 @@ from multiple_minimum_monte_carlo import multiproc
 
 
 def test_batch_dicts_even_split():
-    dicts = [{'a': i} for i in range(6)]
+    dicts = [{"a": i} for i in range(6)]
     batched = multiproc.batch_dicts(dicts.copy(), 3)
     # Expect roughly even distribution
     lengths = [len(b) for b in batched]
@@ -16,7 +16,13 @@ def test_parallel_run_proc_single_worker(tmp_path):
 
     # Wrap the callable to match expected call signature in multiproc.run_func
     def wrapper(**kwargs):
-        return func(**kwargs['args']) if 'args' in kwargs else func(kwargs['x'], kwargs['y'])
+        return (
+            func(**kwargs["args"])
+            if "args" in kwargs
+            else func(kwargs["x"], kwargs["y"])
+        )
 
-    results = multiproc.parallel_run_proc(wrapper, [{'args': {'x': 3, 'y': 4}}], num_workers=1)
+    results = multiproc.parallel_run_proc(
+        wrapper, [{"args": {"x": 3, "y": 4}}], num_workers=1
+    )
     assert results == [7]


### PR DESCRIPTION
I added code to avoid using `multiprocessing` when `parallel=False`, as I was getting pickling errors. I think this may be OS-dependent; `multiprocessing`'s default process spawn method switches between `spawn` and `fork` depending on the operating system used, which is messy. (This also avoids the `mp.Process` startup time, which can be substantial.)

I also ran the code through the `ruff` formatter / linter automatically through `nvim`—no need to merge these, happy to pull out the formatting changes. 

The test suite passes locally except for the multiprocessing tests, which are still giving the the aforementioned error:

``` 
FAILED tests/test_multiproc.py::test_parallel_run_proc_single_worker - AttributeError: Can't pickle local object 'test_parallel_run_proc_single_worker.<locals>.wrapper'
```