### PR TITLE
Adjusting multiprocessing scripts for navigating directories.

### DIFF
--- a/multiple_minimum_monte_carlo/multiproc.py
+++ b/multiple_minimum_monte_carlo/multiproc.py
@@ -1,10 +1,12 @@
 """Module for running functions in parallel on a single node"""
 
 import os
+import shutil
 from typing import List, Dict, Callable
 import torch.multiprocessing as mp
 import math
 import torch
+from pathlib import Path
 
 
 def batch_dicts(dicts: List[Dict], num_workers: int) -> List[List[Dict]]:
@@ -78,27 +80,33 @@ def run_func(func: Callable, input_list: List[Dict], queue: mp.Queue) -> None:
     torch.set_num_threads(1)
     # Make and cd into a batch folder to run calculations in
     batch = input_list[0]["batch"]
-    os.system("mkdir batch_" + str(batch))
-    os.chdir("batch_" + str(batch))
+    original_dir = Path.cwd().resolve()
+    # Use local temp directory (TMPDIR or /tmp) if available
+    temp_base = _get_temp_base_dir()
 
-    # Run the function on each input dictionary
-    # Remove the batch number from the input dictionary
-    for input_dict in input_list:
-        del input_dict["batch"]
-    results = []
-    for input_dict in input_list:
-        try:
-            result = func(**input_dict)
-        except Exception as e:
-            print("Error in batch", batch, ":", e)
-            continue
-        results.append(result)
+    batch_dir = temp_base / f"mmmc_batch_{batch}_{os.getpid()}"
+    batch_dir.mkdir(parents=True, exist_ok=True)
 
-    # Change directory back to the original directory and remove the batch folder
-    os.chdir("..")
-    os.system("rm -r batch_" + str(batch))
+    try:
+        os.chdir(batch_dir)
+        # Run the function on each input dictionary
+        # Remove the batch number from the input dictionary
+        for input_dict in input_list:
+            del input_dict["batch"]
+        results = []
+        for input_dict in input_list:
+            try:
+                result = func(**input_dict)
+            except Exception as e:
+                print("Error in batch", batch, ":", e)
+                continue
+            results.append(result)
+    finally:
+        # Change directory back to the original directory and remove the batch folder
+        # Use absolute path to return - avoids stale file handle on ".."
+        os.chdir(original_dir)
+        shutil.rmtree(batch_dir, ignore_errors=True)
 
-    # Put the results in the queue
     final_dict = {batch: results}
     queue.put_nowait(final_dict)
 

--- a/multiple_minimum_monte_carlo/multiproc.py
+++ b/multiple_minimum_monte_carlo/multiproc.py
@@ -87,13 +87,14 @@ def run_func(func: Callable, input_list: List[Dict], queue: mp.Queue) -> None:
     batch_dir = temp_base / f"mmmc_batch_{batch}_{os.getpid()}"
     batch_dir.mkdir(parents=True, exist_ok=True)
 
+    results = []
     try:
         os.chdir(batch_dir)
         # Run the function on each input dictionary
         # Remove the batch number from the input dictionary
         for input_dict in input_list:
             del input_dict["batch"]
-        results = []
+
         for input_dict in input_list:
             try:
                 result = func(**input_dict)

--- a/multiple_minimum_monte_carlo/multiproc.py
+++ b/multiple_minimum_monte_carlo/multiproc.py
@@ -104,7 +104,10 @@ def run_func(func: Callable, input_list: List[Dict], queue: mp.Queue) -> None:
     finally:
         # Change directory back to the original directory and remove the batch folder
         # Use absolute path to return - avoids stale file handle on ".."
-        os.chdir(original_dir)
+        try:
+            os.chdir(original_dir)
+        except OSError:
+            pass  # Original directory may no longer exist
         shutil.rmtree(batch_dir, ignore_errors=True)
 
     final_dict = {batch: results}

--- a/multiple_minimum_monte_carlo/multiproc.py
+++ b/multiple_minimum_monte_carlo/multiproc.py
@@ -49,6 +49,20 @@ def batch_dicts(dicts: List[Dict], num_workers: int) -> List[List[Dict]]:
     return batched_dicts
 
 
+def _get_temp_base_dir() -> Path:
+    """Get the best temporary directory: TMPDIR > /tmp > cwd."""
+    if tmpdir := os.environ.get('TMPDIR'):
+        tmp_path = Path(tmpdir)
+        if tmp_path.exists() and tmp_path.is_dir():
+            return tmp_path
+
+    tmp_path = Path('/tmp')
+    if tmp_path.exists() and tmp_path.is_dir():
+        return tmp_path
+
+    return Path.cwd()
+
+
 def run_func(func: Callable, input_list: List[Dict], queue: mp.Queue) -> None:
     """
     Run a function in parallel with a list of arguments and puts the results in a queue. Do this in a directory named from the batch number


### PR DESCRIPTION
When using `parallel=True`, I encountered this error on my filesystem which causes the code to hang:
```
multiple_minimum_monte_carlo/multiproc.py", line 84, in run_func
    os.chdir("..")
OSError: [Errno 116] Stale file handle: '..'
```

To help fix this, I converted directory creation and file navigation to use `pathlib` with absolute paths.

I also adjusted the location that temporary directories are created by checking if these paths exist in this order: `TMPDIR`, `/tmp`, or the current directory. This is not necessary and could be removed or made into an optional argument.